### PR TITLE
fix: add hash to arrow icon color

### DIFF
--- a/Front-end/src/pages/NewIncident/index.js
+++ b/Front-end/src/pages/NewIncident/index.js
@@ -49,7 +49,7 @@ export default function NewIncidents() {
                     <p>Descreva o caso detalhadamente para encontrar um heroi para resolver isso.</p>
 
                     <Link className='back-link' to="/profile">
-                        <FiArrowLeft size={16} color="E02041" />
+                        <FiArrowLeft size={16} color="#E02041" />
                         Voltar para home
                     </Link>
                 </section>


### PR DESCRIPTION
## Summary
- ensure FiArrowLeft uses hex color code for consistency

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689ca69b92848332a0f4d7cc5ba97e43