### PR TITLE
docs: fix technology names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <strong>Back-End</strong>
   <ul>
     <li>NodeJS</li>
-    <li>EXpress</li>
+    <li>Express</li>
     <li>SQLite</li>
     <li>Knex</li>
     <li>Celebrate</li>
@@ -31,10 +31,10 @@
 <li>
   <strong>Mobile</strong>
   <ul> 
-    <li>ReactNative</li>
+    <li>React Native</li>
     <li>Expo</li>
     <li>Axios</li>
-    <li>tarn</li>
+    <li>Yarn</li>
     <li>Babel</li>
   </ul>
 </li>


### PR DESCRIPTION
## Summary
- correct Express spelling in backend tech list
- list React Native and Yarn properly in mobile technologies

## Testing
- `npm test --prefix back-end` *(fails: cross-env: not found)*
- `npm install --prefix back-end` *(fails: E403 fetching packages)*
- `CI=true npm test --prefix Front-end` *(fails: no tests found)*
- `npm test --prefix mobile` *(fails: missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ca6a51fac8332b05310f3b4ea781a