### PR TITLE
Handle missing incident on deletion

### DIFF
--- a/back-end/src/controllers/incidentController.js
+++ b/back-end/src/controllers/incidentController.js
@@ -50,6 +50,10 @@ module.exports = {
             .select('ong_id')
             .first()
 
+        if (!incident) {
+            return response.status(404).json({ error: 'Incident not found.' })
+        }
+
         if (incident.ong_id != ong_id) {
             return response.status(401).json({error: 'Operation not permitted. '})
         }


### PR DESCRIPTION
## Summary
- prevent server crash when deleting non-existent incident by returning 404

## Testing
- `npm test` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca572511c8332b876ae7aa2efa01b